### PR TITLE
Remove use of /usr/bin/env to set command environment

### DIFF
--- a/bin/rbenv-sudo
+++ b/bin/rbenv-sudo
@@ -25,4 +25,4 @@ set -eu
 ROOT_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ROOT_PATH="${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:${ROOT_PATH}"
 
-eval command sudo env PATH=\"\$ROOT_PATH\" \"\$@\"
+eval command sudo PATH=\"\$ROOT_PATH\" \"\$@\"


### PR DESCRIPTION
There's no need to use env to set the environment of the command to run. sudo
supports setting environment variables natively, as explained in sudo(8), and
use of 'env' prevents the passing of arguments directly to sudo, such as '-p'.

Before:

```
$ rbenv sudo -p "Enter your password:" echo "hello"
env: -p: No such file or directory
```

After:

```
$ rbenv sudo -p "Enter your password:" echo "hello"
Enter your password:
hello
```
