### PR TITLE
Distinguish between rbenv managed executables

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright (C) 2012-2013, Dan Carley
+Copyright (C) 2013, Mark Van de Vyver (mark@taqtiqa.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ system binaries of the same name.
 
 ## Installation
 
+In you use [rbenv-installer](https://github.com/fesplugas/rbenv-installer):
+
+    rbenv plugin dcarley:rbenv-sudo
+
+Otherwise:
+
 1. Setup [rbenv](https://github.com/sstephenson/rbenv)
 1. Make sure you have a plugins directory:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ system binaries of the same name.
 
 ## Installation
 
-In you use [rbenv-installer](https://github.com/fesplugas/rbenv-installer):
+If you use [rbenv-installer](https://github.com/fesplugas/rbenv-installer):
 
     rbenv plugin dcarley:rbenv-sudo
 

--- a/bin/rbenv-sudo
+++ b/bin/rbenv-sudo
@@ -1,28 +1,21 @@
 #!/usr/bin/env bash
 
-# Copyright (C) 2012, Dan Carley
+# Summary: Runs an rbenv executable via sudo.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to
-# deal in the Software without restriction, including without limitation the
-# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-# sell copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
+# Usage: rbenv sudo
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE
+# This will run an executable that is not 'managed' by rbenv.
+# For instance, given that echo is not within the scope of rbenv, this would be expected to fail:
+#    $rbenv sudo echo 'Hi!'
+# However, this plugin intercepts the command and runs it as would expect:
+#    $sudo echo 'Hi!'
 
-set -eu
 
-ROOT_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-ROOT_PATH="${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:${ROOT_PATH}"
-
-eval command sudo env PATH=\"\$ROOT_PATH\" \"\$@\"
+EXECUTABLE=$1
+shift 1
+RBENV_EXECUTABLE=$(rbenv which $EXECUTABLE)
+if [ $? -eq 0 ]; then
+  sudo $RBENV_EXECUTABLE $*
+else
+  sudo $EXECUTABLE $*
+fi


### PR DESCRIPTION
Runs rbenv executables under sudo without choking on non-rbenv executables. Simpler install instructions.
