### PR TITLE
Detect root's `PATH` at run

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Rubies and Gems from within a `sudo` session.
 
 ## Implementation
 
-It does so by prepending rbenv's `bin/` and `shims/` directories to a
-hardcoded representation of root's `$PATH`. It differs from `rvmsudo` in
-that it doesn't pass your present `$PATH` or any other environment
-variables over to the sudo session, in the hope of damage limitation.
+It does so by prepending rbenv's `bin/` and `shims/` directories to
+root's `$PATH`. It differs from `rvmsudo` in that it doesn't pass your
+present `$PATH` or any other environment variables over to the sudo
+session, in the hope of damage limitation.
 
 It will function with the common sudo configuration of:
 

--- a/bin/rbenv-sudo
+++ b/bin/rbenv-sudo
@@ -22,7 +22,7 @@
 
 set -eu
 
-ROOT_PATH=`sudo env | grep PATH= | sed s/PATH=//`
+ROOT_PATH=`sudo env | grep ^PATH= | sed s/PATH=//`
 ROOT_PATH="${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:${ROOT_PATH}"
 
 eval command sudo env RBENV_VERSION=\"\${RBENV_VERSION:-}\" PATH=\"\$ROOT_PATH\" \"\$@\"

--- a/bin/rbenv-sudo
+++ b/bin/rbenv-sudo
@@ -22,7 +22,7 @@
 
 set -eu
 
-ROOT_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ROOT_PATH=`sudo env | grep PATH= | sed s/PATH=//`
 ROOT_PATH="${RBENV_ROOT}/shims:${RBENV_ROOT}/bin:${ROOT_PATH}"
 
 eval command sudo env RBENV_VERSION=\"\${RBENV_VERSION:-}\" PATH=\"\$ROOT_PATH\" \"\$@\"


### PR DESCRIPTION
This eliminates the hardcoded `PATH` and uses whatever root's `PATH` is at runtime.
